### PR TITLE
Modificando las sentencias SQL para reducir las consultas

### DIFF
--- a/sql/world/command.sql
+++ b/sql/world/command.sql
@@ -1,8 +1,7 @@
-DELETE FROM `command` WHERE `name` IN ('chatcensure');
-DELETE FROM `command` WHERE `name` IN ('chatcensure add');
-DELETE FROM `command` WHERE `name` IN ('chatcensure delete');
-DELETE FROM `command` WHERE `name` IN ('chatcensure reload');
-INSERT INTO `command` (`name`, `security`, `help`) VALUES ('chatcensure', 1, 'Syntax: .chatcensure $subcommand\nType .chatcensure to see the list of all available commands.');
-INSERT INTO `command` (`name`, `security`, `help`) VALUES ('chatcensure add', 1, 'Syntax: .chatcensure add <name>\nBan a word. Please use quotation marks when adding.');
-INSERT INTO `command` (`name`, `security`, `help`) VALUES ('chatcensure delete', 1, 'Syntax: .chatcensure delete <name>\nDelete a banned word. Please use quotation marks when deleting.');
-INSERT INTO `command` (`name`, `security`, `help`) VALUES ('chatcensure reload', 1, 'Syntax: .chatcensure reload\nRealod the chat Censure table.');
+DELETE FROM `command` WHERE `name` IN ('chatcensure', 'chatcensure add', 'chatcensure delete', 'chatcensure reload');
+
+INSERT INTO `command` (`name`, `security`, `help`) VALUES
+('chatcensure', 1, 'Syntax: .chatcensure $subcommand\nType .chatcensure to see the list of all available commands.'),
+('chatcensure add', 1, 'Syntax: .chatcensure add <name>\nBan a word. Please use quotation marks when adding.'),
+('chatcensure delete', 1, 'Syntax: .chatcensure delete <name>\nDelete a banned word. Please use quotation marks when deleting.'),
+('chatcensure reload', 1, 'Syntax: .chatcensure reload\nRealod the chat Censure table.');


### PR DESCRIPTION
Modifique las sentencias SQL para que en vez de ejecutar 8 consultas, se ejecuten solamente 2.
Revísalas de todos modos antes de aprobarlas, pero debería de funcionar.